### PR TITLE
Include all source files in the podspec

### DIFF
--- a/BinaryCodable.podspec
+++ b/BinaryCodable.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.12'
 
-  s.source_files = ['Sources/*.swift', 'Sources/*/*.swift']
+  s.source_files = ['Sources/**/*.swift']
 end


### PR DESCRIPTION
The `BinaryDataCoders` directory was ignored because it did not match the previous `source_files` pattern.